### PR TITLE
Implementación de capa de datos (Redis)

### DIFF
--- a/api/endpoints/endpoints.py
+++ b/api/endpoints/endpoints.py
@@ -3,9 +3,10 @@ from fastapi import APIRouter, HTTPException
 from fastapi.responses import JSONResponse
 from ..structures import ChatRequest, ChatResponse
 from ..services.discutidor3000 import Discutidor3000
+from dotenv import load_dotenv
+load_dotenv()
 
 logger = logging.getLogger(__name__)
-
 discutidor = Discutidor3000(api_key=os.getenv("DEEPSEEK_API_KEY"))
 chat_router = APIRouter()
 
@@ -30,4 +31,18 @@ def chat_endpoint(request: ChatRequest):
             content=response.model_dump())
     except Exception as e:
         logger.error(f"Error en el endpoint /chat: {e}")
+        logger.debug(f"Trazo completo del error:", exc_info=True)
+        return HTTPException(status_code=500, detail=str(e))
+    
+
+@chat_router.get("/conversations")
+def get_conversations():
+    try:
+        conversations = discutidor.get_all_conversations()
+        return JSONResponse(
+            status_code=200,
+            content={"conversations": conversations or {}})
+    except Exception as e:
+        logger.error(f"Error en el endpoint /conversations: {e}")
+        logger.debug(f"Trazo completo del error:", exc_info=True)
         return HTTPException(status_code=500, detail=str(e))

--- a/api/services/__init__.py
+++ b/api/services/__init__.py
@@ -1,0 +1,1 @@
+from .discutidor3000 import Discutidor3000

--- a/api/services/discutidor3000.py
+++ b/api/services/discutidor3000.py
@@ -138,12 +138,6 @@ class Discutidor3000:
             last_updated=datetime.now().isoformat()
         )
         self.conversations[conversation_id] = conversation.model_dump()
-        # self.conversations[conversation_id] = {
-        #     "conversation_id": conversation_id,
-        #     "posture": posture,
-        #     "messages": [
-        #         {"role": "system", "content": self._gen_system_prompt(posture)},
-        #         {"role": "user", "content": initial_message} ]}
         
 
     def _gen_response(self, conversation_id: str) -> Optional[Dict]:

--- a/api/services/redis.py
+++ b/api/services/redis.py
@@ -1,0 +1,73 @@
+import os, json, redis, logging
+from typing import Optional
+
+logger = logging.getLogger(__name__)
+
+from ..structures.structures import Conversation
+
+class RedisService:
+    """Servicio para interactuar con Redis."""
+    def __init__(self):
+        self.redis_url = os.getenv("REDIS_URL", "redis://localhost:6379/0")
+        self.redis = redis.Redis.from_url(
+            self.redis_url,
+            decode_responses=True,
+            socket_timeout=5,
+            retry_on_timeout=True)
+        
+
+    def set_conversation(self, conversation_id: str,
+                         conversation_data: Conversation,
+                         ttl:int = 1_120_000) -> bool:
+        """Almacena conversación en Redis por 2 semanas (por defecto)
+        Args:
+            conversation_id (str): ID de la conversación
+            conversation_data (Conversation): Datos de la conversación
+        Returns:
+            bool: True si se almacenó correctamente, False si hubo error"""
+        try:
+            return self.redis.setex(
+                f"conversation:{conversation_id}",
+                ttl,
+                json.dumps(conversation_data.model_dump()))
+        except redis.RedisError as e:
+            logger.error(f"Error al guardar conversación en Redis: {e}")
+            logger.debug(f"Datos: {conversation_data}")
+            logger.debug(f"e.args: {e.args}\nexc_info: {e.__traceback__}")
+            return False
+        
+    
+    def get_conversation(self, conversation_id: str) -> bool:
+        """Obtiene conversación de Redis
+        Args:
+            conversation_id (str): ID de la conversación
+        Returns:
+            bool: True si se obtuvo correctamente, False si hubo error"""
+        try:
+            data = self.redis.get(f"conversation:{conversation_id}")
+            if data:
+                return Conversation.model_validate(json.loads(data))
+            return None
+        except redis.RedisError as e:
+            logger.error(f"Error al obtener conversación de Redis: {e}")
+            logger.debug(f"conversation_id: {conversation_id}")
+            logger.debug(e.with_traceback(e.__traceback__))
+            logger.debug(f"Data obtenida: {data}")
+            return None
+        
+
+    def get_all_conversations(self) -> Optional[dict]:
+        """Obtiene todas las conversaciones almacenadas en Redis
+        Returns:
+            Optional[dict]: Diccionario con todas las conversaciones o None si hubo error"""
+        try:
+            keys = self.redis.keys("conversation:*")
+            if not keys:
+                logger.debug("No se encontraron conversaciones en Redis.")
+                return None
+            return keys
+        except redis.RedisError as e:
+            logger.error(f"Error al obtener todas las conversaciones de Redis: {e}")
+            logger.debug(e.with_traceback(e.__traceback__))
+            return None
+    

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,12 @@
+
+services:
+  redis:
+    image: redis:7-alpine
+    ports:
+      - "6379:6379"
+    volumes:
+      - redis_data:/data
+    command: redis-server --appendonly yes
+
+volumes:
+  redis_data:

--- a/main.py
+++ b/main.py
@@ -4,7 +4,6 @@ from fastapi.responses import JSONResponse
 from api.endpoints import chat_router
 
 api = FastAPI()
-
 api.include_router(chat_router,
                    prefix="/api/v1",
                    tags=["chat"])

--- a/main.py
+++ b/main.py
@@ -1,7 +1,12 @@
 
+import logging
+
 from fastapi import FastAPI
 from fastapi.responses import JSONResponse
 from api.endpoints import chat_router
+
+logging.basicConfig(level=logging.DEBUG,
+                    format="%(asctime)s - %(name)s - %(levelname)s - %(message)s")
 
 api = FastAPI()
 api.include_router(chat_router,

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 annotated-types==0.7.0
 anyio==4.10.0
+async-timeout==5.0.1
 certifi==2025.8.3
 charset-normalizer==3.4.3
 click==8.2.1
@@ -24,6 +25,7 @@ Pygments==2.19.2
 python-dotenv==1.1.1
 python-multipart==0.0.20
 PyYAML==6.0.2
+redis==6.4.0
 requests==2.32.5
 rich==14.1.0
 rich-toolkit==0.15.1


### PR DESCRIPTION
En esta rama implementé la capa de datos. Se decidió usar Redis para almacenar las conversaciones. El proyecto viene con un `docker-compose.yml` para desplegar Redis de forma local. También se puede especificar un host específico de Redis en las variables de entorno.

El objeto a almacenar en Redis es `Conversations`:
```python
class Conversation(Base):
    """Estructura para conversaciones."""
    conversation_id: str
    posture: str
    messages: List[Message] # todos los mensajes
    created_at: str = datetime.now().isoformat()
    last_updated: str = datetime.now().isoformat()
```
Cada conversación tiene un TTL de 14 días.

Si bien Redis es una base volátil, donde cada 14 días o ante cualquier reinicio de server se pierden los datos, esta implementación permite desplegar el bot a producción sin manejar las conversaciones directamente en la memoria de Python.

Siguientes pasos: Terminar de pulir estructura de código, terminar de documentar proyecto, __implementar tests, despliegue a producción, makefile y tarball con repo.__