### PR TITLE
[Testing] Se implementa capa completa de testing en el proyecto

### DIFF
--- a/.env-example
+++ b/.env-example
@@ -1,2 +1,11 @@
+# API Key de DeepSeek (REQUERIDA)
+# Obtén tu API key en: https://platform.deepseek.com/
 DEEPSEEK_API_KEY=
+
+# URL de Redis (OPCIONAL - por defecto: redis://localhost:6379/0)
+# Ejemplo: redis://usuario:password@host:puerto/db
+REDIS_URL=
+
+# Prefijo de ruta para reverse proxy (OPCIONAL)
+# Ejemplo: /api/v1 para rutas como https://miapp.com/api/v1/chat
 ROOT_PATH=

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,148 @@
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+pip-wheel-metadata/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+*.py,cover
+.hypothesis/
+.pytest_cache/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+db.sqlite3-journal
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# IPython
+profile_default/
+ipython_config.py
+
+# pyenv
+.python-version
+
+# pipenv
+#   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
+#   However, in case of collaboration, if having platform-specific dependencies or dependencies
+#   having no cross-platform support, pipenv may install dependencies that don't work, or not
+#   install all needed dependencies.
+#Pipfile.lock
+
+# PEP 582; used by e.g. github.com/David-OConnor/pyflow
+__pypackages__/
+
+# Celery stuff
+celerybeat-schedule
+celerybeat.pid
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
 .env
 .venv
+env/
 venv/
-__pycache__/
-*.pyc
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# Pyre type checker
+.pyre/
+
+# IDEs
 .vscode/
+.idea/
+*.swp
+*.swo
+*~
+
+# OS generated files
+.DS_Store
+.DS_Store?
+._*
+.Spotlight-V100
+.Trashes
+ehthumbs.db
+Thumbs.db
+
+# Docker
+*.pid

--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ help:
 	@echo ""
 	@echo "  make help     - Muestra este mensaje de ayuda"
 	@echo "  make install  - Instala todos los requisitos para ejecutar el servicio"
-	@echo "  make test     - Ejecuta las pruebas"
+	@echo "  make test     - Ejecuta todas las pruebas con cobertura"
 	@echo "  make run      - Ejecuta el servicio y todos los servicios relacionados en Docker"
 	@echo "  make down     - Detiene todos los servicios en ejecución"
 	@echo "  make clean    - Elimina todos los contenedores y redes"
@@ -24,48 +24,48 @@ check-deps: check-docker check-python
 
 check-docker:
 	@command -v docker >/dev/null 2>&1 || { \
-		echo "❌ Docker No instalado.:"; \
-		echo "   Ubuntu/Debian: sudo apt-get install docker.io docker-compose-plugin"; \
-		echo "   Fedora: sudo dnf install docker docker-compose-plugin"; \
-		echo "   CentOS/RHEL: sudo yum install docker docker-compose"; \
-		echo "   Fedora: sudo dnf install docker docker-compose"; \
-		echo "   macOS: brew install docker docker-compose"; \
-		echo "   Windows: Download from https://docker.com/products/docker-desktop"; \
-		exit 1; \
+	    echo "❌ Docker No instalado.:"; \
+	    echo "   Ubuntu/Debian: sudo apt-get install docker.io docker-compose-plugin"; \
+	    echo "   Fedora: sudo dnf install docker docker-compose-plugin"; \
+	    echo "   CentOS/RHEL: sudo yum install docker docker-compose"; \
+	    echo "   Fedora: sudo dnf install docker docker-compose"; \
+	    echo "   macOS: brew install docker docker-compose"; \
+	    echo "   Windows: Download from https://docker.com/products/docker-desktop"; \
+	    exit 1; \
 	}
 	@command -v docker-compose >/dev/null 2>&1 || command -v docker compose >/dev/null 2>&1 || { \
-		echo "❌ Docker Compose no instalado"; \
-		echo "   Fedora: sudo dnf install docker-compose"; \
-		echo "   Ubuntu/Debian: sudo apt-get install docker-compose-plugin"; \
-		echo "   CentOS/RHEL: sudo yum install docker-compose"; \
-		echo "   Fedora: sudo dnf install docker-compose"; \
-		echo "   Or: pip install docker-compose"; \
-		echo "   Or use Docker Desktop which includes Compose"; \
-		exit 1; \
+	    echo "❌ Docker Compose no instalado"; \
+	    echo "   Fedora: sudo dnf install docker-compose"; \
+	    echo "   Ubuntu/Debian: sudo apt-get install docker-compose-plugin"; \
+	    echo "   CentOS/RHEL: sudo yum install docker-compose"; \
+	    echo "   Fedora: sudo dnf install docker-compose"; \
+	    echo "   Or: pip install docker-compose"; \
+	    echo "   Or use Docker Desktop which includes Compose"; \
+	    exit 1; \
 	}
 
 check-python:
 	@command -v python3 >/dev/null 2>&1 || { \
-		echo "❌ Python 3 no instalado. Por favor instala Python 3.8+:"; \
-		echo "   Ubuntu/Debian: sudo apt-get install python3 python3-pip python3-venv"; \
-		echo "   CentOS/RHEL: sudo yum install python3 python3-pip"; \
-		echo "   Fedora: sudo dnf install python3 python3-pip python3-virtualenv"; \
-		echo "   macOS: brew install python3"; \
-		echo "   Windows: Download from https://python.org/downloads/"; \
-		exit 1; \
+	    echo "❌ Python 3 no instalado. Por favor instala Python 3.8+:"; \
+	    echo "   Ubuntu/Debian: sudo apt-get install python3 python3-pip python3-venv"; \
+	    echo "   CentOS/RHEL: sudo yum install python3 python3-pip"; \
+	    echo "   Fedora: sudo dnf install python3 python3-pip python3-virtualenv"; \
+	    echo "   macOS: brew install python3"; \
+	    echo "   Windows: Download from https://python.org/downloads/"; \
+	    exit 1; \
 	}
 
 # Install all requirements
 install: check-deps
 	@echo "🔧 Instalando dependencias para Discutidor3000 API..."
 	@if [ ! -f .env ]; then \
-		echo "📋 Creando .env desde template..."; \
-		cp .env-example .env; \
-		echo "⚠️  Por favor edita .env y configura DEEPSEEK_API_KEY"; \
+	    echo "📋 Creando .env desde template..."; \
+	    cp .env-example .env; \
+	    echo "⚠️  Por favor edita .env y configura DEEPSEEK_API_KEY"; \
 	fi
 	@if [ ! -d "venv" ]; then \
-		echo "🐍 Creando entorno de Python..."; \
-		python3 -m venv venv; \
+	    echo "🐍 Creando entorno de Python..."; \
+	    python3 -m venv venv; \
 	fi
 	@echo "📦 Instalando dependencias de Python..."
 	@. venv/bin/activate && pip install --upgrade pip
@@ -78,26 +78,30 @@ install: check-deps
 	@echo "   1. Edita .el archivo .env y agrega tu DEEPSEEK_API_KEY"
 	@echo "   2. Ejecuta 'make run' para iniciar todos los servicios"
 
-# Run tests
+# Run all tests with coverage - ÚNICO COMANDO DE TESTING
 test: check-deps
-	@echo "🧪 Ejecutando tests..."
+	@echo "🧪 Ejecutando suite completa de tests..."
 	@if [ ! -d "venv" ]; then \
-		echo "❌ Entorno virtual no encontrado. Ejecuta 'make install'."; \
-		exit 1; \
+	    echo "❌ Entorno virtual no encontrado. Ejecuta 'make install' primero."; \
+	    exit 1; \
 	fi
-	@. venv/bin/activate && pytest -v
-	@echo "✅ Todos los tests se ejecutaron correctamente!!"
+	@echo "📊 Ejecutando tests con cobertura..."
+	@. venv/bin/activate && python -m pytest tests/ -v --cov=api --cov-report=term-missing --cov-report=html
+	@echo ""
+	@echo "✅ Tests completados!"
+	@echo "📊 Reporte detallado de cobertura disponible en: htmlcov/index.html"
+	@echo "🎯 Para ver el reporte: open htmlcov/index.html (macOS) o xdg-open htmlcov/index.html (Linux)"
 
 # Run the service and all related services in Docker
 run: check-deps
 	@echo "🚀 Iniciando Discutidor3000 API y servicios relacionados..."
 	@if [ ! -f .env ]; then \
-		echo "❌ Archivo .env no encontrado. Ejecuta 'make install' primero."; \
-		exit 1; \
+	    echo "❌ Archivo .env no encontrado. Ejecuta 'make install' primero."; \
+	    exit 1; \
 	fi
 	@if ! grep -q "DEEPSEEK_API_KEY=" .env || grep -q "DEEPSEEK_API_KEY=$$" .env; then \
-		echo "❌ DEEPSEEK_API_KEY no configurado en .env. Por favor agrega tu API key."; \
-		exit 1; \
+	    echo "❌ DEEPSEEK_API_KEY no configurado en .env. Por favor agrega tu API key."; \
+	    exit 1; \
 	fi
 	@$(DOCKER_COMPOSE) up --build -d
 	@echo "✅ Los servicios se están iniciando..."

--- a/README.md
+++ b/README.md
@@ -10,58 +10,121 @@ Desarrollada en FastAPI y utilizando el modelo `DeepSeek-V3.1 (Non-thinking Mode
 - 🔄 **Conversaciones persistentes**: Almacenamiento en Redis con TTL de 2 semanas
 - 🚀 **API REST**: Endpoints HTTP para integración fácil
 - 💬 **CLI interactivo**: Interfaz de línea de comandos para pruebas
-- 🧪 **Testing completo**: Suite de tests unitarios con cobertura amplia
+- 🧪 **Testing completo**: Suite de tests unitarios y de integración con cobertura completa
 - 📊 **Logging**: Sistema de logging detallado para debugging
 - 🐳 **Containerización**: Despliegue completo con Docker y Docker Compose
 
-## Instalación Rápida con Makefile
+## Quickstart
 
-Este proyecto incluye un Makefile que automatiza todas las tareas de instalación, testing y despliegue:
 
+Lo primero es clonar el repositorio:
 ```bash
-# Ver todos los comandos disponibles
-make
-
-# Instalar todas las dependencias y configurar el proyecto
-make install
-
-# Ejecutar tests
-make test
-
-# Ejecutar el servicio completo en Docker
-make run
-
-# Detener todos los servicios
-make down
-
-# Limpiar completamente todos los contenedores y volúmenes
-make clean
+git clone https://github.com/econopapi/discutidor3000-api.git
+cd discutidor3000-api
 ```
 
-## Variables de Entorno
+Luego, copia el archivo de ejemplo `.env-example` a `.env` y edítalo para agregar tu API key de DeepSeek y otras variables de entorno según sea necesario:
+```bash
+cp .env-example .env
+# Editar .env y agregar variables de entorno
+```
 
-Las siguientes variables de entorno deben configurarse en el archivo `.env`:
+### Variables de Entorno
+#### Variables requeridas
 
-### Variables requeridas
+```bash
+DEEPSEEK_API_KEY=tu_api_key_aqui
+```
+- **Descripción**: API key de DeepSeek para acceso a los modelos de IA
+- **Requerido**: ✅ Sí
+- **Obtención**: Regístrate en [DeepSeek](https://platform.deepseek.com/) y obtén tu API key
 
-| Variable | Descripción | Ejemplo |
-|----------|-------------|---------|
-| `DEEPSEEK_API_KEY` | **Requerida**. API key de DeepSeek para acceder al modelo de chat | `sk-xxxxxxxxxxxxxxxx` |
-
-### Variables opcionales
-Si se usará Redis fuera del contenedor Docker por default, estas variables pueden ser configuradas:
-
-| Variable | Descripción | Valor por Defecto |
-|----------|-------------|-------------------|
-| `REDIS_URL` | URL de conexión a Redis | `redis://localhost:6379/0` |
-
-### Cómo obtener una API Key de DeepSeek
+#### Cómo obtener una API Key de DeepSeek
 
 1. Visita [https://platform.deepseek.com](https://platform.deepseek.com)
 2. Crea una cuenta o inicia sesión
 3. Ve a la sección de "API Keys"
 4. Genera una nueva API key
 5. Copia la key y agrégala a tu archivo `.env`
+
+#### Variables opcionales
+```bash
+REDIS_URL=redis://localhost:6379/0
+```
+- **Descripción**: URL de conexión a Redis para almacenamiento de conversaciones
+- **Requerido**: ❌ No (usa valor por defecto)
+- **Por defecto**: `redis://localhost:6379/0`
+- **Uso**: Si tienes Redis en otro host/puerto o con autenticación
+
+
+```bash
+ROOT_PATH=/api/v1
+```
+- **Descripción**: Prefijo de ruta base para la API cuando se despliega detrás de un reverse proxy
+- **Requerido**: ❌ No
+- **Por defecto**: Sin prefijo (rutas directas)
+- **Casos de uso**:
+  - **Nginx/Apache**: Si tu API está en `https://midominio.com/api/v1/`
+  - **API Gateway**: Para organizar múltiples servicios bajo rutas específicas
+  - **Docker/Kubernetes**: En despliegues con ingress controllers
+
+#### Ejemplo de ROOT_PATH:
+
+**Sin ROOT_PATH** (desarrollo local):
+```
+http://localhost:8000/chat
+http://localhost:8000/conversations
+```
+
+**Con ROOT_PATH=/api/v1** (producción):
+```
+https://miapp.com/api/v1/chat
+https://miapp.com/api/v1/conversations
+```
+
+## Uso de Makefile
+Este proyecto incluye un Makefile que automatiza todas las tareas de instalación, testing y despliegue:
+
+Para ver los comandos disponibles y su descripción, simplemente ejecuta:
+```bash
+make
+```
+
+Instalar dependencias y configurar el entorno:
+```bash
+make install
+```
+
+Ejecutar la suite completa de tests:
+```bash
+make test
+```
+
+Ejecutar el servicio completo (API + Redis) en contenedores Docker:
+```bash
+make run
+```
+
+Detener todos los servicios:
+```bash
+make down
+```
+
+Limpiar todos los contenedores y volúmenes:
+```bash
+make clean
+```
+
+## Comandos del Makefile
+
+| Comando | Descripción |
+|---------|-------------|
+| `make` o `make help` | Muestra lista de todos los comandos disponibles |
+| `make install` | Instala todas las dependencias necesarias. Detecta herramientas faltantes y proporciona instrucciones |
+| `make test` | Ejecuta toda la suite de tests |
+| `make run` | Ejecuta el servicio y todas las dependencias en Docker |
+| `make down` | Detiene todos los servicios en ejecución |
+| `make clean` | Detiene y elimina todos los contenedores, redes y volúmenes |
 
 ## Instalación Manual (Alternativa)
 
@@ -150,17 +213,6 @@ El CLI permite:
 - Iniciar nuevas conversaciones con `/n`
 - Salir con `/q`
 - Conversación continua una vez establecida la postura
-
-## Comandos del Makefile
-
-| Comando | Descripción |
-|---------|-------------|
-| `make` o `make help` | Muestra lista de todos los comandos disponibles |
-| `make install` | Instala todas las dependencias necesarias. Detecta herramientas faltantes y proporciona instrucciones |
-| `make test` | Ejecuta toda la suite de tests |
-| `make run` | Ejecuta el servicio y todas las dependencias en Docker |
-| `make down` | Detiene todos los servicios en ejecución |
-| `make clean` | Detiene y elimina todos los contenedores, redes y volúmenes |
 
 ## API Reference
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Una API HTTP que sirve un chatbot cuya única misión es defender, argumentar y discutir a favor de cualquier tema, por absurdo que sea, asignado por el usuario.
 
-Desarrollada en FastAPI y utilizando el modelo `DeepSeek-V3.1 (Non-thinking Mode)` de DeepSeek.
+Desarrollada en FastAPI, con Redis como capa de datos y utilizando el modelo `DeepSeek-V3.1 (Non-thinking Mode)` de DeepSeek.
 
 ## Características
 

--- a/README.md
+++ b/README.md
@@ -283,24 +283,102 @@ discutidor3000-api/
 
 Ejecutar la suite completa de tests:
 
+Usando el Makefile (recomendado):
 ```bash
-# Usando Makefile (recomendado)
 make test
-
-# O manualmente
-pytest -v
-
-# O usando unittest
+```
+O directamente con pytest:
+```bash
+pytest -v --cov=api --cov-report=html
+```
+O usando unittest:
+```bash
 python -m unittest discover tests -v
 ```
 
-Los tests cubren:
-- Inicialización del chatbot
-- Generación de prompts del sistema
-- Comunicación con API de DeepSeek
-- Extracción de posturas
-- Gestión de conversaciones
-- Formateo de respuestas
+### Cobertura de Testing
+
+La suite de testing incluye **44 tests** organizados en 4 categorías con **97% de cobertura de código**:
+
+#### 🧪 Tests Unitarios (25 tests)
+
+**Discutidor3000 Service** (`test_discutidor3000.py`):
+- ✅ Inicialización del chatbot (con/sin API key)
+- ✅ Generación de prompts del sistema
+- ✅ Comunicación con API de DeepSeek
+- ✅ Extracción de posturas desde mensajes
+- ✅ Inicialización y gestión de conversaciones
+- ✅ Generación de respuestas del bot
+- ✅ Formateo de respuestas
+- ✅ Manejo de errores y excepciones personalizadas
+
+**Redis Service** (`test_redis.py`):
+- ✅ Operaciones CRUD de conversaciones
+- ✅ Manejo de errores de conexión a Redis
+- ✅ Serialización/deserialización de datos
+- ✅ Gestión de TTL y expiración
+
+#### 🌐 Tests de API (9 tests)
+
+**Endpoints** (`test_endpoints.py`):
+- ✅ Endpoint de health check (`/`)
+- ✅ Endpoint de chat (`/chat`) con nuevas conversaciones
+- ✅ Endpoint de chat con conversaciones existentes
+- ✅ Endpoint de listado de conversaciones (`/conversations`)
+- ✅ Manejo de errores HTTP (404, 500, 422)
+- ✅ Validación de requests malformados
+
+#### 🔗 Tests de Integración (3 tests)
+
+**Flujos Completos** (`test_integration.py`):
+- ✅ Flujo end-to-end de nueva conversación
+- ✅ Flujo de continuación de conversación existente
+- ✅ Manejo de errores en cadena
+
+#### ⚙️ Configuración de Testing
+
+**Fixtures Compartidas** (`conftest.py`):
+- 🔧 Mocks reutilizables de Redis y servicios externos
+- 🔧 Datos de prueba consistentes (conversaciones, mensajes)
+- 🔧 Configuración de entorno de testing
+
+### Reportes de Cobertura
+
+Al ejecutar `make test` se generan automáticamente:
+
+- **Reporte en terminal**: Muestra líneas no cubiertas
+- **Reporte HTML**: Disponible en `htmlcov/index.html`
+
+```bash
+# Ver reporte HTML de cobertura
+open htmlcov/index.html      # macOS
+xdg-open htmlcov/index.html  # Linux
+```
+
+### Estructura de Tests
+
+```
+tests/
+├── conftest.py              # Configuración y fixtures compartidas
+├── test_discutidor3000.py   # Tests del servicio principal (17 tests)
+├── test_redis.py            # Tests del servicio Redis (10 tests)
+├── test_endpoints.py        # Tests de endpoints HTTP (9 tests)
+└── test_integration.py      # Tests de integración (3 tests)
+```
+
+### Tecnologías de Testing
+
+- **pytest**: Framework principal de testing
+- **pytest-cov**: Generación de reportes de cobertura
+- **unittest.mock**: Mocking de dependencias externas
+- **FastAPI TestClient**: Testing de endpoints HTTP
+
+Los tests cubren todos los casos críticos incluyendo:
+- ✅ Casos exitosos (happy path)
+- ✅ Manejo de errores y excepciones
+- ✅ Validación de datos de entrada/salida
+- ✅ Integración entre componentes
+- ✅ Mocking de servicios externos (DeepSeek API, Redis)
 
 ## Configuración Avanzada
 

--- a/api/services/redis.py
+++ b/api/services/redis.py
@@ -43,6 +43,7 @@ class RedisService:
             conversation_id (str): ID de la conversación
         Returns:
             bool: True si se obtuvo correctamente, False si hubo error"""
+        data = None
         try:
             data = self.redis.get(f"conversation:{conversation_id}")
             if data:

--- a/requirements.txt
+++ b/requirements.txt
@@ -26,6 +26,8 @@ pydantic==2.11.7
 pydantic_core==2.33.2
 Pygments==2.19.2
 pytest==8.4.2
+pytest-cov==6.0.0
+pytest-asyncio==0.25.0
 python-dotenv==1.1.1
 python-multipart==0.0.20
 PyYAML==6.0.2

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,58 @@
 import sys
 import os
+import pytest
+from unittest.mock import Mock, patch
+from datetime import datetime
 
+# Agregar el directorio raíz al path
 project_root = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 sys.path.insert(0, project_root)
+
+@pytest.fixture
+def mock_redis():
+    """Fixture para mockear Redis."""
+    with patch('api.services.redis.redis.Redis.from_url') as mock:
+        redis_instance = Mock()
+        mock.return_value = redis_instance
+        yield redis_instance
+
+@pytest.fixture
+def mock_discutidor_redis():
+    """Fixture específico para mockear Redis en Discutidor3000."""
+    with patch('api.services.discutidor3000.RedisService') as mock:
+        redis_service = Mock()
+        mock.return_value = redis_service
+        yield redis_service
+
+@pytest.fixture
+def sample_conversation():
+    """Fixture con una conversación de ejemplo."""
+    from api.structures import Conversation, Message
+    return Conversation(
+        conversation_id="test_id",
+        posture="Test posture",
+        messages=[
+            Message(role="system", content="System prompt"),
+            Message(role="user", content="User message")
+        ],
+        created_at="2025-03-25T12:00:00",
+        last_updated="2025-03-25T12:00:00"
+    )
+
+@pytest.fixture
+def sample_message():
+    """Fixture con un mensaje de ejemplo."""
+    from api.structures import Message
+    return Message(role="user", content="Test message")
+
+@pytest.fixture
+def api_key():
+    """Fixture con API key de prueba."""
+    return "test_api_key"
+
+@pytest.fixture
+def mock_datetime():
+    """Fixture para mockear datetime."""
+    with patch('api.services.discutidor3000.datetime') as mock_dt:
+        mock_dt.now.return_value.isoformat.return_value = "2025-03-25T12:00:00"
+        yield mock_dt

--- a/tests/test_discutidor3000.py
+++ b/tests/test_discutidor3000.py
@@ -1,23 +1,18 @@
 """
 Tests para la lógica principal de Discutidor3000
-(api.services.discutidor3000.Discutidor3000)
-
-Estos tests usan unittest y mock para simular dependencias externas.
-10 tests que cubren:
-- Inicialización del objeto Discutidor3000 (test_init_success, test_init_no_api_key)
-- Generación del system prompt (test_gen_system_prompt)
-- Solicitud a la API de DeepSeek (test_api_request)
-- Obtención de la postura del mensaje inicial (test_get_posture)
-- Inicialización de la conversación (test_init_conversation)
-- Generación de la respuesta del bot (test_gen_response)
-- Formateo de la respuesta (test_format_response)
-- Iniciar nueva conversación (test_chat_new_conversation)
-- Continuar conversación existente (test_continue_conversation)
+Cobertura completa de todas las funcionalidades
 """
 
 import unittest
+import json
 from unittest.mock import patch, Mock
-from api.services.discutidor3000 import Discutidor3000
+import pytest
+
+from api.services.discutidor3000 import (
+    Discutidor3000, 
+    ConversationNotFoundError, 
+    PostureExtractionError
+)
 from api.structures import ChatResponse, Message, Conversation
 
 class TestDiscutidor3000(unittest.TestCase):
@@ -25,108 +20,115 @@ class TestDiscutidor3000(unittest.TestCase):
     def setUp(self):
         """Configuración de fixtures para cada test."""
         self.api_key = "test_api_key"
-        self.discutidor = Discutidor3000(api_key=self.api_key)
+        with patch('api.services.discutidor3000.RedisService'):
+            self.discutidor = Discutidor3000(api_key=self.api_key)
 
-    
     def test_init_success(self):
-        """Test de inicialización de objeto exitosa.
-        Verifica que los atributos mínimos se configuren correctamente."""
+        """Test de inicialización exitosa."""
         self.assertEqual(self.discutidor.api_key, self.api_key)
         self.assertEqual(self.discutidor.api_base, "https://api.deepseek.com")
-        self.assertEqual(self.discutidor.api_endpoint, "/chat/completions")
         self.assertEqual(self.discutidor.model, "deepseek-chat")
         self.assertIsNotNone(self.discutidor.redis)
 
-
     def test_init_no_api_key(self):
-        """Test de inicialización de objeto sin API Key.
-        Verifica que se lance ValueError si no se proporciona api_key."""
+        """Test de inicialización sin API key."""
         with self.assertRaises(ValueError) as context:
-            Discutidor3000(api_key=None)
-
+            with patch('api.services.discutidor3000.RedisService'):
+                Discutidor3000(api_key=None)
+        self.assertIn("API key is required", str(context.exception))
 
     def test_gen_system_prompt(self):
-        """Test de generación del system prompt.
-        Verifica que el prompt generado contenga la postura dada."""
-        posture = "Python debería ser un lenguaje de programación tipado estáticamente."
+        """Test de generación del system prompt."""
+        posture = "Python es mejor que Java"
         prompt = self.discutidor._gen_system_prompt(posture)
         self.assertIn(posture, prompt)
-        self.assertIn(
-            f"Recuerda, tu objetivo es defender la postura: {posture}",
-            prompt)
-        
+        self.assertIn("defender la postura", prompt)
 
     @patch('api.services.discutidor3000.requests.post')
-    def test_api_request(self, mock_post):
-        """Test de solicitud a API de DeepSeek.
-        Verifica que la solicitud se realice correctamente y se maneje la respuesta."""
+    def test_api_request_success(self, mock_post):
+        """Test de solicitud exitosa a API."""
         mock_response = Mock()
         mock_response.status_code = 200
         mock_response.json.return_value = {
-            "id": "test_id",
-            "object": "chat.completion",
-            "created": 1234567890,
-            "model": "deepseek-chat",
-            "choices": [
-                {
-                    "index": 0,
-                    "message": {
-                        "role": "assistant",
-                        "content": "Test response"
-                    },
-                    "logprobs": None,
-                    "finish_reason": "stop"
-                }
-            ],
-            "usage": {
-                "prompt_tokens": 10,
-                "completion_tokens": 10,
-                "total_tokens": 20,
-                "prompt_tokens_details": {
-                    "cached_tokens": 0
-                },
-                "prompt_cache_hit_tokens": 0,
-                "prompt_cache_miss_tokens": 10
-            },
-            "system_fingerprint": "test_fingerprint"}
+            "choices": [{"message": {"content": "Test response"}}]
+        }
         mock_post.return_value = mock_response
-        messages = [{"role": "user", "content": "Test"}]
-        result = self.discutidor._api_request(messages)
+
+        result = self.discutidor._api_request([{"role": "user", "content": "test"}])
         self.assertIsNotNone(result)
         self.assertEqual(result["choices"][0]["message"]["content"], "Test response")
 
+    @patch('api.services.discutidor3000.requests.post')
+    def test_api_request_error(self, mock_post):
+        """Test de error en API request."""
+        mock_response = Mock()
+        mock_response.status_code = 500
+        mock_response.text = "Internal Server Error"
+        mock_post.return_value = mock_response
+
+        result = self.discutidor._api_request([{"role": "user", "content": "test"}])
+        self.assertIsNone(result)
+
+    @patch('api.services.discutidor3000.requests.post')
+    def test_api_request_with_json_format(self, mock_post):
+        """Test de request con formato JSON."""
+        mock_response = Mock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {
+            "choices": [{"message": {"content": '{"posture": "Test"}'}}]
+        }
+        mock_post.return_value = mock_response
+
+        result = self.discutidor._api_request(
+            [{"role": "user", "content": "test"}], 
+            use_json=True
+        )
+        self.assertIsNotNone(result)
 
     @patch.object(Discutidor3000, '_api_request')
-    def test_get_posture(self, mock_api_request):
-        """Test de obtención de postura del mensaje inicial"""
+    def test_get_posture_success(self, mock_api_request):
+        """Test de extracción exitosa de postura."""
         mock_api_request.return_value = {
-            "choices": [{"message": {"content": { "posture": "Test posture" }}}]
+            "choices": [{"message": {"content": '{"posture": "Test posture"}'}}]
         }
 
-        message = "Defiende que Python debería ser un lenguaje de programación tipado estáticamente."
-        result = self.discutidor._get_posture(message)
+        result = self.discutidor._get_posture("Defend that Python is better")
         self.assertEqual(result, "Test posture")
 
+    @patch.object(Discutidor3000, '_api_request')
+    def test_get_posture_api_error(self, mock_api_request):
+        """Test de error en extracción de postura."""
+        mock_api_request.return_value = None
+
+        result = self.discutidor._get_posture("Test message")
+        self.assertIsNone(result)
+
+    @patch.object(Discutidor3000, '_api_request')
+    def test_get_posture_json_error(self, mock_api_request):
+        """Test de error de JSON en extracción de postura."""
+        mock_api_request.return_value = {
+            "choices": [{"message": {"content": "invalid json"}}]
+        }
+
+        result = self.discutidor._get_posture("Test message")
+        self.assertIsNone(result)
 
     @patch('api.services.discutidor3000.datetime')
     def test_init_conversation(self, mock_datetime):
-        """Test de inicialización de conversación.
-        Verifica que la conversación se inicie y registre correctamente."""
+        """Test de inicialización de conversación."""
         mock_datetime.now.return_value.isoformat.return_value = "2025-03-25T12:00:00"
+        
         with patch.object(self.discutidor.redis, 'set_conversation') as mock_set:
             mock_set.return_value = True
-            conversation_id = "test_id"
-            posture = "Test posture"
-            initial_message = "Test message"
-            self.discutidor._init_conversation(
-                conversation_id, posture, initial_message)
+            
+            self.discutidor._init_conversation("test_id", "test_posture", "test_message")
             mock_set.assert_called_once()
 
-
     @patch('api.services.discutidor3000.datetime')
-    def test_gen_response(self, mock_datetime):
-        """Test de generación de respuesta."""
+    def test_gen_response_success(self, mock_datetime):
+        """Test de generación exitosa de respuesta."""
         mock_datetime.now.return_value.isoformat.return_value = "2025-03-25T12:00:00"
+        
         conversation = Conversation(
             conversation_id="test_id",
             posture="Test posture",
@@ -134,9 +136,30 @@ class TestDiscutidor3000(unittest.TestCase):
                 Message(role="system", content="System prompt"),
                 Message(role="user", content="User message")
             ],
-            created_at=mock_datetime.now.return_value.isoformat(),
-            last_updated=mock_datetime.now.return_value.isoformat())
+            created_at="2025-03-25T12:00:00",
+            last_updated="2025-03-25T12:00:00"
+        )
         
+        with patch.object(self.discutidor.redis, 'get_conversation') as mock_get:
+            with patch.object(self.discutidor.redis, 'set_conversation') as mock_set:
+                with patch.object(self.discutidor, '_api_request') as mock_api:
+                    mock_get.return_value = conversation
+                    mock_set.return_value = True
+                    mock_api.return_value = {
+                        "choices": [{"message": {"content": "Bot response"}}]
+                    }
+                    
+                    result = self.discutidor._gen_response("test_id")
+                    self.assertIsNotNone(result)
+                    self.assertEqual(result["response"], "Bot response")
+
+    def test_gen_response_not_found(self):
+        """Test de respuesta cuando no se encuentra conversación."""
+        with patch.object(self.discutidor.redis, 'get_conversation') as mock_get:
+            mock_get.return_value = None
+            
+            with self.assertRaises(ValueError):
+                self.discutidor._gen_response("nonexistent_id")
 
     def test_format_response(self):
         """Test de formateo de respuesta."""
@@ -145,44 +168,114 @@ class TestDiscutidor3000(unittest.TestCase):
             "messages": [
                 {"role": "system", "content": "System prompt"},
                 {"role": "user", "content": "User message"},
-                {"role": "assistant", "content": "Assistant message"} ]}
+                {"role": "assistant", "content": "Assistant message"}
+            ]
+        }
+        
         result = self.discutidor._format_response(conversation_data)
         self.assertIsInstance(result, ChatResponse)
         self.assertEqual(result.conversation_id, "test_id")
-        self.assertEqual(len(result.message), 2)
+        self.assertEqual(len(result.message), 2)  # Excluding system prompt
 
-
-    @patch.object(Discutidor3000, 'new_conversation')
-    def test_chat_new_conversation(self, mock_new_conversation):
-        """Test de método para iniciar nueva conversación."""
-        mock_response = {"conversation_id": "test_id", "response": "Bot response"}
-        mock_new_conversation.return_value = mock_response
+    @patch.object(Discutidor3000, '_get_posture')
+    @patch.object(Discutidor3000, '_init_conversation')
+    @patch.object(Discutidor3000, '_gen_response')
+    @patch('api.services.discutidor3000.uuid4')
+    def test_new_conversation_success(self, mock_uuid, mock_gen, mock_init, mock_posture):
+        """Test de nueva conversación exitosa."""
+        mock_uuid.return_value = Mock()
+        mock_uuid.return_value.__str__ = Mock(return_value="test_id")
+        mock_posture.return_value = "Test posture"
+        mock_gen.return_value = {
+            "conversation_id": "test_id",
+            "response": "Bot response",
+            "messages": []
+        }
         
         with patch.object(self.discutidor, '_format_response') as mock_format:
             mock_format.return_value = ChatResponse(conversation_id="test_id", message=[])
             
-            result = self.discutidor.chat("Test message")
-            
-            mock_new_conversation.assert_called_once_with("Test message")
-            mock_format.assert_called_once_with(mock_response)    
+            result = self.discutidor.new_conversation("Test message")
+            self.assertIsNotNone(result)
 
+    @patch.object(Discutidor3000, '_get_posture')
+    def test_new_conversation_posture_error(self, mock_posture):
+        """Test de error al extraer postura en nueva conversación."""
+        mock_posture.return_value = None
+        
+        with self.assertRaises(PostureExtractionError):
+            self.discutidor.new_conversation("Test message")
+
+    @patch.object(Discutidor3000, '_gen_response')
+    @patch('api.services.discutidor3000.datetime')
+    def test_continue_conversation_success(self, mock_datetime, mock_gen):
+        """Test de continuar conversación existente."""
+        mock_datetime.now.return_value.isoformat.return_value = "2025-03-25T12:00:00"
+        
+        conversation = Conversation(
+            conversation_id="test_id",
+            posture="Test posture",
+            messages=[Message(role="user", content="Previous message")],
+            created_at="2025-03-25T11:00:00",
+            last_updated="2025-03-25T11:00:00"
+        )
+        
+        mock_gen.return_value = {
+            "conversation_id": "test_id",
+            "response": "Bot response",
+            "messages": []
+        }
+        
+        with patch.object(self.discutidor.redis, 'get_conversation') as mock_get:
+            with patch.object(self.discutidor.redis, 'set_conversation') as mock_set:
+                with patch.object(self.discutidor, '_format_response') as mock_format:
+                    mock_get.return_value = conversation
+                    mock_set.return_value = True
+                    mock_format.return_value = ChatResponse(conversation_id="test_id", message=[])
+                    
+                    result = self.discutidor.continue_conversation("test_id", "New message")
+                    self.assertIsNotNone(result)
+
+    def test_continue_conversation_not_found(self):
+        """Test de continuar conversación inexistente."""
+        with patch.object(self.discutidor.redis, 'get_conversation') as mock_get:
+            mock_get.return_value = None
+            
+            with self.assertRaises(ConversationNotFoundError):
+                self.discutidor.continue_conversation("nonexistent_id", "Test message")
+
+    @patch.object(Discutidor3000, 'new_conversation')
+    def test_chat_new_conversation(self, mock_new):
+        """Test de chat con nueva conversación."""
+        mock_new.return_value = ChatResponse(conversation_id="test_id", message=[])
+        
+        result = self.discutidor.chat("Test message")
+        mock_new.assert_called_once_with("Test message")
 
     @patch.object(Discutidor3000, 'continue_conversation')
-    def test_continue_conversation(self, mock_continue):
-        """Test de método para continuar conversación existente."""
-        mock_response = {
-            "conversation_id": "test_id",
-            "response": "Bot response" }
-        mock_continue.return_value = mock_response
-        with patch.object(self.discutidor, '_format_response') as mock_format:
-            mock_format.return_value = ChatResponse(
-                conversation_id="test_id",
-                message = [])
-            result = self.discutidor.chat(
-                message="Test message",
-                conversation_id="test_id")
+    def test_chat_continue_conversation(self, mock_continue):
+        """Test de chat continuando conversación."""
+        mock_continue.return_value = ChatResponse(conversation_id="test_id", message=[])
+        
+        result = self.discutidor.chat("Test message", "test_id")
+        mock_continue.assert_called_once_with("test_id", "Test message")
 
+    def test_get_all_conversations_success(self):
+        """Test de obtener todas las conversaciones exitosamente."""
+        with patch.object(self.discutidor.redis, 'get_all_conversations') as mock_get:
+            mock_get.return_value = ["conversation:1", "conversation:2"]
+            
+            result = self.discutidor.get_all_conversations()
+            self.assertIsNotNone(result)
+            self.assertIn("conversations", result)
 
-    
+    def test_get_all_conversations_error(self):
+        """Test de error al obtener conversaciones."""
+        with patch.object(self.discutidor.redis, 'get_all_conversations') as mock_get:
+            mock_get.side_effect = Exception("Redis error")
+            
+            result = self.discutidor.get_all_conversations()
+            self.assertIsNone(result)
 
-
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_endpoints.py
+++ b/tests/test_endpoints.py
@@ -1,0 +1,132 @@
+"""
+Tests para los endpoints de la API
+Cubre todos los endpoints y casos de error
+"""
+
+import unittest
+import os
+from unittest.mock import patch, Mock
+from fastapi.testclient import TestClient
+from fastapi import FastAPI
+
+from api.endpoints.endpoints import chat_router
+from api.services.discutidor3000 import ConversationNotFoundError, PostureExtractionError
+from api.structures import ChatResponse, Message
+
+# Crear una aplicación FastAPI para testing
+app = FastAPI()
+app.include_router(chat_router, prefix="/api/v1")
+client = TestClient(app)
+
+class TestEndpoints(unittest.TestCase):
+
+    def test_hola_endpoint(self):
+        """Test del endpoint raíz."""
+        response = client.get("/api/v1/")
+        self.assertEqual(response.status_code, 200)
+        self.assertIn("Discutidor3000 API", response.json()["mensaje"])
+
+    @patch('api.endpoints.endpoints.discutidor')
+    def test_chat_endpoint_success(self, mock_discutidor):
+        """Test del endpoint de chat exitoso."""
+        mock_response = ChatResponse(
+            conversation_id="test_id",
+            message=[Message(role="user", content="Test message")]
+        )
+        mock_discutidor.chat.return_value = mock_response
+        
+        response = client.post(
+            "/api/v1/chat",
+            json={"message": "Test message", "conversation_id": None}
+        )
+        
+        self.assertEqual(response.status_code, 200)
+        self.assertIn("conversation_id", response.json())
+
+    @patch('api.endpoints.endpoints.discutidor')
+    def test_chat_endpoint_none_response(self, mock_discutidor):
+        """Test del endpoint de chat con respuesta None."""
+        mock_discutidor.chat.return_value = None
+        
+        response = client.post(
+            "/api/v1/chat",
+            json={"message": "Test message", "conversation_id": None}
+        )
+        
+        self.assertEqual(response.status_code, 500)
+
+    @patch('api.endpoints.endpoints.discutidor')
+    def test_chat_endpoint_conversation_not_found(self, mock_discutidor):
+        """Test del endpoint de chat con conversación no encontrada."""
+        mock_discutidor.chat.side_effect = ConversationNotFoundError("Conversation not found")
+        
+        response = client.post(
+            "/api/v1/chat",
+            json={"message": "Test message", "conversation_id": "nonexistent"}
+        )
+        
+        self.assertEqual(response.status_code, 404)
+
+    @patch('api.endpoints.endpoints.discutidor')
+    def test_chat_endpoint_posture_extraction_error(self, mock_discutidor):
+        """Test del endpoint de chat con error de extracción de postura."""
+        mock_discutidor.chat.side_effect = PostureExtractionError("Cannot extract posture")
+        
+        response = client.post(
+            "/api/v1/chat",
+            json={"message": "Test message", "conversation_id": None}
+        )
+        
+        self.assertEqual(response.status_code, 500)
+
+    @patch('api.endpoints.endpoints.discutidor')
+    def test_chat_endpoint_generic_error(self, mock_discutidor):
+        """Test del endpoint de chat con error genérico."""
+        mock_discutidor.chat.side_effect = Exception("Generic error")
+        
+        response = client.post(
+            "/api/v1/chat",
+            json={"message": "Test message", "conversation_id": None}
+        )
+        
+        self.assertEqual(response.status_code, 500)
+
+    @patch('api.endpoints.endpoints.discutidor')
+    def test_conversations_endpoint_success(self, mock_discutidor):
+        """Test del endpoint de conversaciones exitoso."""
+        mock_discutidor.get_all_conversations.return_value = {
+            "conversations": ["conversation:1", "conversation:2"]
+        }
+        
+        response = client.get("/api/v1/conversations")
+        
+        self.assertEqual(response.status_code, 200)
+        self.assertIn("conversations", response.json())
+
+    @patch('api.endpoints.endpoints.discutidor')
+    def test_conversations_endpoint_none_result(self, mock_discutidor):
+        """Test del endpoint de conversaciones con resultado None."""
+        mock_discutidor.get_all_conversations.return_value = None
+        
+        response = client.get("/api/v1/conversations")
+        
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json()["conversations"], {})
+
+    @patch('api.endpoints.endpoints.discutidor')
+    def test_conversations_endpoint_error(self, mock_discutidor):
+        """Test del endpoint de conversaciones con error."""
+        mock_discutidor.get_all_conversations.side_effect = Exception("Database error")
+        
+        response = client.get("/api/v1/conversations")
+        
+        self.assertEqual(response.status_code, 500)
+
+    def test_chat_endpoint_invalid_request(self):
+        """Test del endpoint de chat con request inválido."""
+        response = client.post("/api/v1/chat", json={"invalid": "data"})
+        
+        self.assertEqual(response.status_code, 422)  # Validation error
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -1,0 +1,102 @@
+"""
+Tests de integración que prueban el flujo completo
+"""
+
+import unittest
+from unittest.mock import patch, Mock
+import json
+
+from api.services.discutidor3000 import Discutidor3000
+from api.structures import Conversation, Message
+
+class TestIntegration(unittest.TestCase):
+
+    def setUp(self):
+        """Setup para tests de integración."""
+        with patch('api.services.discutidor3000.RedisService'):
+            self.discutidor = Discutidor3000(api_key="test_api_key")
+
+    @patch('api.services.discutidor3000.requests.post')
+    def test_complete_new_conversation_flow(self, mock_post):
+        """Test del flujo completo de nueva conversación."""
+        # Mock para extracción de postura
+        posture_response = Mock()
+        posture_response.status_code = 200
+        posture_response.json.return_value = {
+            "choices": [{"message": {"content": '{"posture": "Python is better than Java"}'}}]
+        }
+        
+        # Mock para respuesta del bot
+        chat_response = Mock()
+        chat_response.status_code = 200
+        chat_response.json.return_value = {
+            "choices": [{"message": {"content": "I totally agree! Python is superior because..."}}]
+        }
+        
+        mock_post.side_effect = [posture_response, chat_response]
+        
+        with patch.object(self.discutidor.redis, 'set_conversation') as mock_set:
+            with patch.object(self.discutidor.redis, 'get_conversation') as mock_get:
+                mock_set.return_value = True
+                mock_get.return_value = Conversation(
+                    conversation_id="test_id",
+                    posture="Python es mejor que JavaScript",
+                    messages=[
+                        Message(role="system", content="System prompt"),
+                        Message(role="user", content="Defiende que Python es mejor que JavaScript"),
+                        Message(role="assistant", content="Totalmente de acuerdo! Python es superior porque...")
+                    ],
+                    created_at="2025-03-25T12:00:00",
+                    last_updated="2025-03-25T12:00:00"
+                )
+                
+                with patch('api.services.discutidor3000.uuid4') as mock_uuid:
+                    mock_uuid.return_value = Mock()
+                    mock_uuid.return_value.__str__ = Mock(return_value="test_id")
+                    
+                    result = self.discutidor.chat("Defend that Python is better than Java")
+                    
+                    self.assertIsNotNone(result)
+                    self.assertEqual(result.conversation_id, "test_id")
+
+    def test_complete_continue_conversation_flow(self):
+        """Test del flujo completo de continuar conversación."""
+        existing_conversation = Conversation(
+            conversation_id="test_id",
+            posture="Python is better than Java",
+            messages=[
+                Message(role="system", content="System prompt"),
+                Message(role="user", content="Previous message")
+            ],
+            created_at="2025-03-25T11:00:00",
+            last_updated="2025-03-25T11:00:00"
+        )
+        
+        with patch.object(self.discutidor.redis, 'get_conversation') as mock_get:
+            with patch.object(self.discutidor.redis, 'set_conversation') as mock_set:
+                with patch('api.services.discutidor3000.requests.post') as mock_post:
+                    mock_get.return_value = existing_conversation
+                    mock_set.return_value = True
+                    
+                    chat_response = Mock()
+                    chat_response.status_code = 200
+                    chat_response.json.return_value = {
+                        "choices": [{"message": {"content": "Continuing the argument..."}}]
+                    }
+                    mock_post.return_value = chat_response
+                    
+                    result = self.discutidor.chat("Tell me more", "test_id")
+                    
+                    self.assertIsNotNone(result)
+                    self.assertEqual(result.conversation_id, "test_id")
+
+    def test_error_handling_chain(self):
+        """Test de manejo de errores en cadena."""
+        with patch.object(self.discutidor, '_get_posture') as mock_posture:
+            mock_posture.return_value = None
+            
+            with self.assertRaises(Exception):
+                self.discutidor.chat("Test message")
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_redis.py
+++ b/tests/test_redis.py
@@ -1,0 +1,127 @@
+"""
+Tests para RedisService
+Cubre todas las operaciones de Redis con mocks
+"""
+
+import unittest
+from unittest.mock import patch, Mock
+import json
+import redis
+import pytest
+
+from api.services.redis import RedisService
+from api.structures import Conversation, Message
+
+class TestRedisService(unittest.TestCase):
+
+    def setUp(self):
+        """Setup para cada test."""
+        with patch('api.services.redis.redis.Redis.from_url'):
+            self.redis_service = RedisService()
+
+    def test_init_success(self):
+        """Test de inicialización exitosa."""
+        with patch('api.services.redis.redis.Redis.from_url') as mock_redis:
+            service = RedisService()
+            mock_redis.assert_called_once()
+
+    def test_set_conversation_success(self):
+        """Test de almacenar conversación exitosamente."""
+        conversation = Conversation(
+            conversation_id="test_id",
+            posture="Test posture",
+            messages=[Message(role="user", content="Test message")],
+            created_at="2025-03-25T12:00:00",
+            last_updated="2025-03-25T12:00:00"
+        )
+        
+        with patch.object(self.redis_service.redis, 'setex') as mock_setex:
+            mock_setex.return_value = True
+            
+            result = self.redis_service.set_conversation("test_id", conversation)
+            self.assertTrue(result)
+            mock_setex.assert_called_once()
+
+    def test_set_conversation_redis_error(self):
+        """Test de error de Redis al almacenar conversación."""
+        conversation = Conversation(
+            conversation_id="test_id",
+            posture="Test posture",
+            messages=[],
+            created_at="2025-03-25T12:00:00",
+            last_updated="2025-03-25T12:00:00"
+        )
+        
+        with patch.object(self.redis_service.redis, 'setex') as mock_setex:
+            mock_setex.side_effect = redis.RedisError("Connection error")
+            
+            result = self.redis_service.set_conversation("test_id", conversation)
+            self.assertFalse(result)
+
+    def test_get_conversation_success(self):
+        """Test de obtener conversación exitosamente."""
+        conversation_data = {
+            "conversation_id": "test_id",
+            "posture": "Test posture",
+            "messages": [{"role": "user", "content": "Test message"}],
+            "created_at": "2025-03-25T12:00:00",
+            "last_updated": "2025-03-25T12:00:00"
+        }
+        
+        with patch.object(self.redis_service.redis, 'get') as mock_get:
+            mock_get.return_value = json.dumps(conversation_data)
+            
+            result = self.redis_service.get_conversation("test_id")
+            self.assertIsInstance(result, Conversation)
+            self.assertEqual(result.conversation_id, "test_id")
+
+    def test_get_conversation_not_found(self):
+        """Test de conversación no encontrada."""
+        with patch.object(self.redis_service.redis, 'get') as mock_get:
+            mock_get.return_value = None
+            
+            result = self.redis_service.get_conversation("test_id")
+            self.assertIsNone(result)
+
+    def test_get_conversation_redis_error(self):
+        """Test de error de Redis al obtener conversación."""
+        with patch.object(self.redis_service.redis, 'get') as mock_get:
+            mock_get.side_effect = redis.RedisError("Connection error")
+            
+            result = self.redis_service.get_conversation("test_id")
+            self.assertIsNone(result)
+
+    def test_get_conversation_json_decode_error(self):
+        """Test de error de decodificación JSON."""
+        with patch.object(self.redis_service.redis, 'get') as mock_get:
+            mock_get.return_value = "invalid json"
+            
+            result = self.redis_service.get_conversation("test_id")
+            self.assertIsNone(result)
+
+    def test_get_all_conversations_success(self):
+        """Test de obtener todas las conversaciones exitosamente."""
+        with patch.object(self.redis_service.redis, 'keys') as mock_keys:
+            mock_keys.return_value = ["conversation:1", "conversation:2"]
+            
+            result = self.redis_service.get_all_conversations()
+            self.assertEqual(len(result), 2)
+
+    def test_get_all_conversations_empty(self):
+        """Test de obtener conversaciones cuando no hay ninguna."""
+        with patch.object(self.redis_service.redis, 'keys') as mock_keys:
+            mock_keys.return_value = []
+            
+            result = self.redis_service.get_all_conversations()
+            self.assertIsNone(result)
+
+    def test_get_all_conversations_redis_error(self):
+        """Test de error de Redis al obtener todas las conversaciones."""
+        with patch.object(self.redis_service.redis, 'keys') as mock_keys:
+            mock_keys.side_effect = redis.RedisError("Connection error")
+            
+            result = self.redis_service.get_all_conversations()
+            self.assertIsNone(result)
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
En esta PR, se implementa una capa completa de testing soobre el proyecto, que incluye:

* Tests unitarios
* Tests de endpoints en la API
* Tests de integración
* Reportes de cobertura

# 🧪 Tests unitarios (25 tests)

## Discutidor3000
Tests para `api.services.discutidor3000.Discutidor3000` [d83ba3366777e982aaf1eaf95e14b7ccb45d26d5]:
* Inicialización de chatbot (con/sin API Key)
* Generación del _system prompt_
* Conexión con API de DeepSeek
* Extracción de postura a defender desde mensajes del usuario
* Inicialización y gestión de conversaciones
* Generación de respuestas del bot
* Estructuración y formateo de respuestas
* Manejo de errores y excepciones personalizadas

## RedisService
Tests para `api.services.redis.RedisService` [187fb12044ecb35cf739f68e1c7049c26674f7db]:
* Operaciones CRUD en conversaciones
* Manejo de errores de conexión a Redis
* Serialización/deserialización de datos
* Gestión de TTL y expiración

# 🌐 Tests de endpoints (9 tests)
Tests sobre los endpoints de la API `api.endpoints` [e811c0870e5873e044772d761e7d91142adb1b6a]:
* Endpoint health check (`/`)
* Nuevas conversaciones en endpoint de chat (`/chat`)
* Conversaciones existentes en endpoint de chat (`/chat`)
* Endpoint de listado de conversaciones (`/conversations`)
* Manejo de errores HTTP (404, 500, 422)
* Validación de requests


# 🔗 Tests de integración (3 tests)
Tests de funcionamiento de flujos completos (`tests/test_integration.py`) [1e656e2fd5bbf1957433c029bcc1d90657ba2240]:
* Flujo _end-to-end_ de nueva conversación
* Flujo de continuación de conversación existente
* Manejo de errores en cadena

# 📋 Reportes de cobertura
Al ejecutar `make test` se genera de forma automática reporte en **terminal** y también en formato **HTML**, disponible en `htmlcov/index.html`  

<img width="450" alt="image" src="https://github.com/user-attachments/assets/cc7a7eff-951f-4a49-8cb9-539b01eb9272" />

## Comentarios adicionales

Este testing mejorado ya se ha implementado en el Makefile, por lo que basta con ejecutar el siguiente comando:
```bash
make test
```

La estrucutra de archivos para esta nueva capa de testing:
```
tests/
├── conftest.py              # Configuración y fixtures compartidas
├── test_discutidor3000.py   # Tests del servicio principal (17 tests)
├── test_redis.py            # Tests del servicio Redis (10 tests)
├── test_endpoints.py        # Tests de endpoints HTTP (9 tests)
└── test_integration.py      # Tests de integración (3 tests)
```

El stack de testing:
* **pytest**: Herramienta principal de testing
*  **pystest-cov**: Para generar reportes de cobertura
* **unittest.mock**: Para hacer _mock_ de dependencias externas
* **FastAPI TestClient**: Para endpoints HTTP