### PR TITLE
Cambio de proveedor de infra (de DeepSeekAPI a OpenRouterAPI)

### DIFF
--- a/.env-example
+++ b/.env-example
@@ -1,6 +1,6 @@
-# API Key de DeepSeek (REQUERIDA)
-# Obtén tu API key en: https://platform.deepseek.com/
-DEEPSEEK_API_KEY=
+# API key para OpenRouter (REQUIRED)
+# Puedes obtener una en https://openrouter.ai
+OPENROUTER_API_KEY=
 
 # URL de Redis (OPCIONAL - por defecto: redis://localhost:6379/0)
 # Ejemplo: redis://usuario:password@host:puerto/db

--- a/Makefile
+++ b/Makefile
@@ -61,7 +61,7 @@ install: check-deps
 	@if [ ! -f .env ]; then \
 	    echo "📋 Creando .env desde template..."; \
 	    cp .env-example .env; \
-	    echo "⚠️  Por favor edita .env y configura DEEPSEEK_API_KEY"; \
+	    echo "⚠️  Por favor edita .env y configura OPENROUTER_API_KEY"; \
 	fi
 	@if [ ! -d "venv" ]; then \
 	    echo "🐍 Creando entorno de Python..."; \
@@ -75,7 +75,7 @@ install: check-deps
 	@echo "✅ Instalación completada!"
 	@echo ""
 	@echo "📝 Siguientes pasos:"
-	@echo "   1. Edita .el archivo .env y agrega tu DEEPSEEK_API_KEY"
+	@echo "   1. Edita .el archivo .env y agrega tu OPENROUTER_API_KEY"
 	@echo "   2. Ejecuta 'make run' para iniciar todos los servicios"
 
 # Run all tests with coverage - ÚNICO COMANDO DE TESTING
@@ -99,8 +99,8 @@ run: check-deps
 	    echo "❌ Archivo .env no encontrado. Ejecuta 'make install' primero."; \
 	    exit 1; \
 	fi
-	@if ! grep -q "DEEPSEEK_API_KEY=" .env || grep -q "DEEPSEEK_API_KEY=$$" .env; then \
-	    echo "❌ DEEPSEEK_API_KEY no configurado en .env. Por favor agrega tu API key."; \
+	@if ! grep -q "OPENROUTER_API_KEY=" .env || grep -q "OPENROUTER_API_KEY=$$" .env; then \
+	    echo "❌ OPENROUTER_API_KEY no configurado en .env. Por favor agrega tu API key."; \
 	    exit 1; \
 	fi
 	@$(DOCKER_COMPOSE) up --build -d

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ ROOT_PATH=/api/v1
 **Sin ROOT_PATH** (desarrollo local):
 ```
 http://localhost:8000/api/v1/chat
-http://localhost:8000/API/V1/conversations
+http://localhost:8000/api/v1/conversations
 ```
 
 **Con ROOT_PATH=/discutidor** (producción):

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Una API HTTP que sirve un chatbot cuya única misión es defender, argumentar y discutir a favor de cualquier tema, por absurdo que sea, asignado por el usuario.
 
-Desarrollada en FastAPI, con Redis como capa de datos y utilizando el modelo `DeepSeek-V3.1 (Non-thinking Mode)` de DeepSeek.
+Desarrollada en FastAPI, con Redis como capa de datos y utilizando el modelo `DeepSeek-V3.1-Terminus` de DeepSeek, a través de OperRouter como proveedor.
 
 ## Características
 
@@ -33,17 +33,17 @@ cp .env-example .env
 #### Variables requeridas
 
 ```bash
-DEEPSEEK_API_KEY=tu_api_key_aqui
+OPENROUTER_API_KEY=tu_api_key_aqui
 ```
-- **Descripción**: API key de DeepSeek para acceso a los modelos de IA
+- **Descripción**: API key de OpenRouter para acceso a los modelos de IA de DeepSeek
 - **Requerido**: ✅ Sí
-- **Obtención**: Regístrate en [DeepSeek](https://platform.deepseek.com/) y obtén tu API key
+- **Obtención**: Regístrate en [OpenRouter](https://openrouter.ai/) y obtén tu API key
 
-#### Cómo obtener una API Key de DeepSeek
+#### Cómo obtener una API Key de OpenRouter
 
-1. Visita [https://platform.deepseek.com](https://platform.deepseek.com)
+1. Visita [https://openrouter.ai/](https://openrouter.ai/)
 2. Crea una cuenta o inicia sesión
-3. Ve a la sección de "API Keys"
+3. Ve a [Settings > API Keys](https://openrouter.ai/settings/preferences)
 4. Genera una nueva API key
 5. Copia la key y agrégala a tu archivo `.env`
 
@@ -72,14 +72,14 @@ ROOT_PATH=/api/v1
 
 **Sin ROOT_PATH** (desarrollo local):
 ```
-http://localhost:8000/chat
-http://localhost:8000/conversations
+http://localhost:8000/api/v1/chat
+http://localhost:8000/API/V1/conversations
 ```
 
-**Con ROOT_PATH=/api/v1** (producción):
+**Con ROOT_PATH=/discutidor** (producción):
 ```
-https://miapp.com/api/v1/chat
-https://miapp.com/api/v1/conversations
+https://miapp.com/discutidor/api/v1/chat
+https://miapp.com/discutidor/api/v1/conversations
 ```
 
 ## Uso de Makefile
@@ -159,7 +159,7 @@ pip install -r requirements.txt
 4. **Configurar variables de entorno**
 ```bash
 cp .env-example .env
-# Editar .env y agregar tu DEEPSEEK_API_KEY
+# Editar .env y agregar tus variables de entorno
 ```
 
 5. **Iniciar Redis**
@@ -385,7 +385,7 @@ Los tests cubren todos los casos críticos incluyendo:
 ### Parámetros del Modelo
 
 El chatbot usa los siguientes parámetros por defecto:
-- **Modelo**: `deepseek-chat`
+- **Modelo**: `deepseek/deepseek-v3.1-terminus` (a través de OpenRouter)
 - **Temperatura**: `0.7`
 - **Max tokens**: `3750`
 
@@ -418,8 +418,8 @@ Por defecto, Redis se configura con:
 
 ### Problemas Comunes
 
-**Error: "DEEPSEEK_API_KEY not set"**
-- Asegúrate de que el archivo `.env` existe y contiene `DEEPSEEK_API_KEY=tu_api_key`
+**Error: "OPENROUTER_API_KEY not set"**
+- Asegúrate de que el archivo `.env` existe y contiene `OPENROUTER_API_KEY=tu_api_key`
 
 **Error: "Docker is not installed"**
 - Instala Docker siguiendo las instrucciones que proporciona `make install`

--- a/api/endpoints/endpoints.py
+++ b/api/endpoints/endpoints.py
@@ -12,7 +12,7 @@ from dotenv import load_dotenv
 load_dotenv()
 
 logger = logging.getLogger(__name__)
-discutidor = Discutidor3000(api_key=os.getenv("DEEPSEEK_API_KEY"))
+discutidor = Discutidor3000(api_key=os.getenv("OPENROUTER_API_KEY"))
 chat_router = APIRouter()
 
 @chat_router.get("/")

--- a/api/services/discutidor3000.py
+++ b/api/services/discutidor3000.py
@@ -27,10 +27,10 @@ class Discutidor3000:
     """Chatbot que defiente una postura dada durante toda la conversación."""
 
     def __init__(self, api_key: Optional[str] = None):
-        self.api_base = "https://api.deepseek.com"
+        self.api_base = "https://openrouter.ai/api/v1"
         self.api_endpoint = "/chat/completions"
         self.api_key = api_key
-        self.model = "deepseek-chat"
+        self.model = "deepseek/deepseek-v3.1-terminus"
         self.temperature = 0.7
         self.max_tokens = 3750
         self.headers = {

--- a/cli.py
+++ b/cli.py
@@ -15,7 +15,7 @@ def init():
           - /q : salir""")
     
     # Initialize Discutidor3000 instance
-    api_key = os.getenv('DEEPSEEK_API_KEY')
+    api_key = os.getenv('OPENROUTER_API_KEY')
     discutidor = Discutidor3000(api_key=api_key)
     
     current_conversation_id = None

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,7 +17,7 @@ services:
     ports:
       - "8000:8000"
     environment:
-      - DEEPSEEK_API_KEY=${DEEPSEEK_API_KEY}
+      - OPENROUTER_API_KEY=${OPENROUTER_API_KEY}
       - REDIS_URL=redis://redis:6379/0
       - ROOT_PATH=${ROOT_PATH}
     depends_on:


### PR DESCRIPTION
Esta PR presenta pocos cambios en el código del proyecto, pero implica un cambio importante a nivel estructural: **cambio de proveedor de infraestructura para LLM, de [DeepSeek API](https://platform.deepseek.com) a [OpenRouter API](https://openrouter.ai)**, usando ahora el modelo `deepseek-v3.1-terminus`. El cambio sustancial se encuentra en este commit [5d7c379a656bf407872831e6974ab9fd801f77b0]

# Motivos del cambio: Pobre _performance_ de la API
Uno de los mayores problemas en este proyecto eran los tiempos de respuesta: __14 segundos en promedio y hasta 25 segundos en los peores casos 😖__

Intenté refactorizar el servicio principal `Discutidor3000` para optimizar parámetros de llamada a la API de DeepSeek, optimizar prompts del sistema, manejar pool de conexiones HTTP, y otros intentos que funcionaron poco o nada para reducir los tiempos de la API y ni siquiera llegaron como cambios al código en el repo debido a la casi nula relación esfuerzo-beneficio.

Era obvio que **el cuello de botella se encontraba en la propia API de DeepSeek**, ya que indagando un poco, descubrí que en general, la API de DeepSeek es más lenta que competidores como OpenAI. De hecho, este es uno de sus mayores problemas.

Lo más plausible hubiese sido simplemente pivotar hacia la API de OpenAI directamente, y quitarme esos problemas de latencia, pero no quise tomar ese camino por dos razones:

1. Querer que este proyecto sea, desde el núcleo, lo más _Open-Source_ posible
2. Querer explorar y probar con proveedores de infra para IA

Finalmente, creo que este tipo de modelos, más abiertos que el _mainstream_, dan pie a que la IA sea más accesible para la sociedad en temas clave como investigación y desarrollo, no solo consumo, aunque en este caso el proyecto sólo consuma el LLM.

Dicho esto, decidí seguir usando un modelo de DeepSeek, pero a través de  [OpenRouter API](https://openrouter.ai), que es un servicio que proveee, en interfaz unificada, acceso a varios modelos con distintos proveedores de infra.

# Resultados con OpenRouter
Hacer este cambio  **mejoró el _performance_ de la API de Discutidor3000 en  más de 60%** , manteniendo a DeepSeek como modelo, con la misma implementación de código, logrando tiempos de respuesta de __5 segundos en promedio, y hasta 8 segundos en los peores casos 🔥__

Mi objetivo era tener un tiempo de respuesta de ~10 segundos, pero la mejora superó mis expectativas. Aquí una comparativa rápida:

| Proveedor/Modelo | Tiempo medio de respuesta | Tiempo máximo de respuesta |
|--------|--------|--------|
| DeepSeekAPI - `deepseek-chat` | ~14 segundos | ~25 segundos |
| OpenRouterAPI - `deepseek-v3.1-terminus` | ~5 segundos | ~8 segundos | 

Los resultados hablan por sí solos.